### PR TITLE
replace union punning with C++ class with bitshifts

### DIFF
--- a/Sources/2022_blaster/Firmware/Firmware.ino
+++ b/Sources/2022_blaster/Firmware/Firmware.ino
@@ -140,28 +140,27 @@ void chatter_master_loop(){
 
 void handle_badge_packet(LinkDataPacket packet)
 {
-  if (packet.raw == 0) return;
+  if (packet.get_raw() == 0) return;
 
-  switch (packet.command){
+  switch (packet.get_command()){
     case CMD_ACK:
       Serial.println("Link_in ACK");
       //not supposed to happen
       break;
     case CMD_MODE:
-      ModeParameter payload;
-      payload.raw = packet.parameter;
+      ModeParameter payload(packet.get_parameter());
       Serial.print("  Mode: ");
-      Serial.println(payload.mode);
+      Serial.println(payload.get_mode());
       Serial.print("  Team: ");
-      Serial.println(payload.team);
+      Serial.println(payload.get_team());
       Serial.print("  Action: ");
-      Serial.println(payload.action);
+      Serial.println(payload.get_action());
       Serial.print("  ID: ");
-      Serial.println(payload.id);
+      Serial.println(payload.get_id());
       Serial.print("  hp: ");
-      Serial.println(payload.hp);
+      Serial.println(payload.get_hp());
       Serial.print("  ready: ");
-      Serial.println(payload.ready);
+      Serial.println(payload.get_ready());
 
       sendAck();
       break;
@@ -248,10 +247,10 @@ void handle_play_animation(LinkDataPacket packet) {
 
 void handle_ir_packet(IrDataPacket packet)
 {
-  if (packet.raw == 0)
+  if (packet.get_raw() == 0)
     return;
   Serial.println("Received message from IR");
-  switch (packet.action)
+  switch (packet.get_action())
   {
   case eActionDamage:
     Serial.println("eActionDamage");
@@ -274,7 +273,7 @@ void handle_ir_packet(IrDataPacket packet)
 
 void handle_damage_received(IrDataPacket packet)
 {
-  if (packet.channel == channel && packet.team != activeTeam())
+  if (packet.get_channel() == channel && packet.get_team() != activeTeam())
   {
     Animations::stealth(false);
    
@@ -287,7 +286,7 @@ void handle_damage_received(IrDataPacket packet)
     {
     case eGMTimeout:
       // action here depends on game mode
-      Animations::crash(packet.team, hit_timeout);
+      Animations::crash(packet.get_team(), hit_timeout);
       if (hitpoints) hitpoints--;
       Serial.print("Hitpoints: ");
       Serial.println(hitpoints);
@@ -390,20 +389,18 @@ void damageShot()
   Serial.println("Pang!");
   Serial.println(activeTeam());
 
-  IrDataPacket packet;
-  packet.raw = 0;
-  packet.team = activeTeam();
-  packet.channel = channel;
-  packet.player_id = player_id;
-  packet.action = trigger_action;
-  packet.action_param = 1;
+  IrDataPacket packet(0);
+  packet.set_team(activeTeam());
+  packet.set_channel(channel);
+  packet.set_player_id(player_id);
+  packet.set_action(trigger_action);
+  packet.set_action_param(1);
   Data.transmit(packet);
 
   delay(100);
 
-  LinkDataPacket dp;
-  dp.raw = 0;
-  dp.command = CMD_TRIGGER;
+  LinkDataPacket dp(0);
+  dp.set_command(CMD_TRIGGER);
   Data.transmit(dp);
 
 /*
@@ -508,10 +505,9 @@ void modeSelection(){
 void sendAck()
 {
   delay(10);
-  LinkDataPacket dp;
-  dp.raw = 0;
-  dp.command = CMD_ACK;
-  dp.parameter = 1;  // Something to ensure we don't send out a 00000 packet
+  LinkDataPacket dp(0);
+  dp.set_command(CMD_ACK);
+  dp.set_parameter(1);  // Something to ensure we don't send out a 00000 packet
   Data.transmit(dp);
 }
 

--- a/Sources/2022_blaster/Firmware/data.cpp
+++ b/Sources/2022_blaster/Firmware/data.cpp
@@ -1,6 +1,60 @@
 #include "data.h"
 #include <Arduino.h>
 
+IrDataPacket::IrDataPacket(){};
+IrDataPacket::IrDataPacket(uint32_t raw){this->raw=raw;};
+
+uint32_t IrDataPacket::get_raw()         { return this->raw; }
+uint8_t IrDataPacket::get_channel()      { return (this->raw & 0b00000000000000000000000000000001) >> 0; }
+uint8_t IrDataPacket::get_team()         { return (this->raw & 0b00000000000000000000000000001110) >> 1; }
+uint8_t IrDataPacket::get_action()       { return (this->raw & 0b00000000000000000000000000110000) >> 4; }
+uint8_t IrDataPacket::get_action_param() { return (this->raw & 0b00000000000000000000001111000000) >> 6; }
+uint16_t IrDataPacket::get_player_id()   { return (this->raw & 0b00000000001111111111110000000000) >> 10; }
+uint8_t IrDataPacket::get_crc()          { return (this->raw & 0b00111111110000000000000000000000) >> 22; }
+uint8_t IrDataPacket::get_unused()       { return (this->raw & 0b11000000000000000000000000000000) >> 30; }
+
+void IrDataPacket::set_raw(uint32_t raw)                  { this->raw = raw; }
+void IrDataPacket::set_channel(uint8_t channel)           { this->raw &= ~(0b1 << 0); this->raw |= (channel & 0b1) << 0;}
+void IrDataPacket::set_team(uint8_t team)                 { this->raw &= ~(0b111 << 1); this->raw |= (team & 0b111) << 1;}
+void IrDataPacket::set_action(uint8_t action)             { this->raw &= ~(0b11 << 4); this->raw |= (action & 0b11) << 4;}
+void IrDataPacket::set_action_param(uint8_t action_param) { this->raw &= ~(0b1111 << 6); this->raw |= (action_param & 0b1111) << 6;}
+void IrDataPacket::set_player_id(uint16_t player_id)      { this->raw &= ~((uint32_t)0b111111111111 << 10); this->raw |= (player_id & 0b111111111111) << 10;}
+void IrDataPacket::set_crc(uint8_t crc)                   { this->raw &= ~((uint32_t)0b11111111 << 22); this->raw |= (crc & (uint32_t)0b11111111) << 22;}
+void IrDataPacket::set_unused(uint8_t unused)             { this->raw &= ~((uint32_t)0b11 << 30); this->raw |= (unused & (uint32_t)0b11) << 30;}
+
+LinkDataPacket::LinkDataPacket(){};
+LinkDataPacket::LinkDataPacket(uint32_t raw){this->raw=raw;};
+
+uint32_t LinkDataPacket::get_raw()         { return this->raw; }
+uint8_t LinkDataPacket::get_command()      { return (this->raw & 0b00000000000000000000000000000111) >> 0; }
+uint32_t LinkDataPacket::get_parameter()   { return (this->raw & 0b00000000111111111111111111111000) >> 3; }
+uint8_t LinkDataPacket::get_crc()          { return (this->raw & 0b11111111000000000000000000000000) >> 24; }
+
+void LinkDataPacket::set_raw(uint32_t raw)             { this->raw = raw; }
+void LinkDataPacket::set_command(uint8_t command)      { this->raw &= ~(0b111 << 0); this->raw |= (command & 0b111) << 0;}
+void LinkDataPacket::set_parameter(uint32_t parameter) { this->raw &= ~(0b111111111111111111111 << 3); this->raw |= (parameter & 0b111111111111111111111) << 3;}
+void LinkDataPacket::set_crc(uint8_t crc)              { this->raw &= ~((uint32_t)0b11111111 << 24); this->raw |= (crc & (uint32_t)0b11111111) << 24;}
+
+
+ModeParameter::ModeParameter(){};
+ModeParameter::ModeParameter(uint32_t raw){this->raw=raw;};
+
+uint32_t ModeParameter::get_raw()   { return (this->raw & 0b00000000000111111111111111111111) >> 0; }
+uint8_t ModeParameter::get_mode()   { return (this->raw & 0b00000000000000000000000000000001) >> 0; }
+uint8_t ModeParameter::get_team()   { return (this->raw & 0b00000000000000000000000000001110) >> 1; }
+uint8_t ModeParameter::get_action() { return (this->raw & 0b00000000000000000000000000110000) >> 4; }
+uint16_t ModeParameter::get_id()    { return (this->raw & 0b00000000000000011111111111000000) >> 6; }
+uint8_t ModeParameter::get_hp()     { return (this->raw & 0b00000000000011100000000000000000) >> 17; }
+uint8_t ModeParameter::get_ready()  { return (this->raw & 0b00000000000100000000000000000000) >> 20; }
+
+void ModeParameter::set_raw(uint32_t raw)      { this->raw &= ~(0b111111111111111111111 << 0); this->raw |= (raw & 0b111111111111111111111) << 0;}
+void ModeParameter::set_mode(uint8_t mode)     { this->raw &= ~(0b1 << 0); this->raw |= (mode & 0b1) << 0;}
+void ModeParameter::set_team(uint8_t team)     { this->raw &= ~(0b111 << 1); this->raw |= (team & 0b111) << 1;}
+void ModeParameter::set_action(uint8_t action) { this->raw &= ~(0b11 << 4); this->raw |= (action & 0b11) << 4;}
+void ModeParameter::set_id(uint16_t id)        { this->raw &= ~((uint32_t)0b11111111111 << 6); this->raw |= (id & (uint32_t)0b11111111111) << 6;}
+void ModeParameter::set_hp(uint8_t hp)         { this->raw &= ~((uint32_t)0b111 << 17); this->raw |= (hp & (uint32_t)0b111) << 17;}
+void ModeParameter::set_ready(uint8_t ready)   { this->raw &= ~((uint32_t)0b1 << 20); this->raw |= (ready & (uint32_t)0b1) << 20;}
+
 
 /* #region DataReader */
 void DataReader::handlePinChange(bool state)
@@ -190,31 +244,29 @@ IrDataPacket _data::readIr() //add overload to bypass command type validation?
 {
   if (ir1_reader.isDataReady())
   {
-    IrDataPacket p;
-    p.raw = ir1_reader.getPacket();
-    Serial.println(p.raw);
-    p.raw = calculateCRC(p.raw);
-    if (p.crc == 0) 
+    IrDataPacket p(ir1_reader.getPacket());
+    Serial.println(p.get_raw());
+    p.set_raw(calculateCRC(p.get_raw()));
+    if (p.get_crc() == 0) 
     {
       ir2_reader.reset();
-      return p;   
+      return p;
       }
   }
 
   if (ir2_reader.isDataReady())
   {
-    IrDataPacket p;
-    p.raw = ir2_reader.getPacket();
-    p.raw = calculateCRC(p.raw);
-    if (p.crc == 0) 
+    IrDataPacket p(ir2_reader.getPacket());
+    Serial.println(p.get_raw());
+    p.set_raw(calculateCRC(p.get_raw()));
+    if (p.get_crc() == 0) 
     {
       ir1_reader.reset();
-      return p;   
+      return p;
       }
   }
 
-  auto emptyPacket = IrDataPacket();
-  emptyPacket.raw = 0;
+  auto emptyPacket = IrDataPacket(0);
   return emptyPacket;
 }
 
@@ -223,15 +275,14 @@ LinkDataPacket _data::readBadge()
   if (badge_reader.isDataReady())
   {
     LinkDataPacket p;
-    p.raw = badge_reader.getPacket();
-    p.raw = calculateCRC(p.raw);
-    if (p.crc == 0) 
+    p.set_raw(badge_reader.getPacket());
+    p.set_raw(calculateCRC(p.get_raw()));
+    if (p.get_crc() == 0) 
     {
       return p;   
     }
   }
-  auto emptyPacket = LinkDataPacket();
-  emptyPacket.raw = 0;
+  auto emptyPacket = LinkDataPacket(0);
   return emptyPacket;
 }
 
@@ -273,10 +324,10 @@ void _data::transmit(IrDataPacket packet)
   Serial.println("*");
   disableReceive(eAllDevices);
 
-  packet.crc = 0;
-  packet.raw = calculateCRC(packet.raw);
+  packet.set_crc(0);
+  packet.set_raw(calculateCRC(packet.get_raw()));
 
-  prepare_pulse_train(packet.raw);
+  prepare_pulse_train(packet.get_raw());
   transmit_ir = true;
   setup_ir_carrier();
   transmitting = true;
@@ -291,10 +342,10 @@ void _data::transmit(LinkDataPacket packet)
   Serial.println("Link SEnd");
   disableReceive(eAllDevices);
 
-  packet.crc = 0;
-  packet.raw = calculateCRC(packet.raw);
+  packet.set_crc(0);
+  packet.set_raw(calculateCRC(packet.get_raw()));
 
-  prepare_pulse_train(packet.raw);
+  prepare_pulse_train(packet.get_raw());
   transmit_badge = true;
   pinMode(BADGELINK_PIN, OUTPUT);
   transmitting = true;
@@ -394,8 +445,7 @@ void _data::receive_ISR(bool ir1, bool ir2, bool badge)
 
 /* #endregion */
 
-//todo investigate if static can be removed
-static _data &Data = Data.getInstance();
+_data &Data = Data.getInstance();
 
 ISR(TIMER2_COMPA_vect)
 {

--- a/Sources/2022_blaster/Firmware/data.h
+++ b/Sources/2022_blaster/Firmware/data.h
@@ -45,66 +45,101 @@ enum Action : uint8_t
 #define CMD_TEAM 4
 #define CMD_ANIMATION 5
 
-union IrDataPacket
+/**
+ * @brief IR data packet
+ * holds the 32 ir bits in a private uint32_t
+ * structure: return type - field name - nr of bits
+ *  uint8_t channel: 1;
+ *  uint8_t team: 3;
+ *  uint8_t action: 2;
+ *  uint8_t action_param: 4;
+ *  uint16_t player_id: 12;
+ *  uint8_t crc: 8;
+ *  uint8_t unused: 2;
+ */
+class IrDataPacket
 {
+private:
   uint32_t raw;
-  struct
-  {
-    uint8_t channel: 1;
-    uint8_t team: 3;
-    uint8_t action: 2;
-    uint8_t action_param: 4;
-    uint16_t player_id: 12;
-    uint8_t crc: 8;
-  };
+public:
+  IrDataPacket();
+  IrDataPacket(uint32_t raw);
+  uint32_t get_raw();
+  void set_raw(uint32_t raw);
+  uint8_t get_channel();
+  void set_channel(uint8_t channel);
+  uint8_t get_team();
+  void set_team(uint8_t team);
+  uint8_t get_action();
+  void set_action(uint8_t action);
+  uint8_t get_action_param();
+  void set_action_param(uint8_t action_param);
+  uint16_t get_player_id();
+  void set_player_id(uint16_t player_id);
+  uint8_t get_crc();
+  void set_crc(uint8_t crc);
+  uint8_t get_unused();
+  void set_unused(uint8_t unused);
 };
 
-union LinkDataPacket
+/**
+ * @brief Link Data Packet on badge blaster link communication
+ * holds the 32 ir bits in a private uint32_t
+ * structure: return type - field name - nr of bits
+ * uint8_t command: 3;
+ * uint32_t parameter: 21;
+ * uint8_t crc: 8;
+ */
+class LinkDataPacket
 {
+private:
   uint32_t raw;
-  struct
-  {
-    uint8_t command: 3;
-    uint32_t parameter: 21;
-    uint8_t crc: 8;
-  };
+public:
+  LinkDataPacket();
+  LinkDataPacket(uint32_t raw);
+  uint32_t get_raw();
+  void set_raw(uint32_t raw);
+  uint8_t get_command();
+  void set_command(uint8_t command);
+  uint32_t get_parameter();
+  void set_parameter(uint32_t parameter);
+  uint8_t get_crc();
+  void set_crc(uint8_t crc);
 };
 
-union ShotParameter
+/**
+ * @brief Mode Parameter: 21 bits of LinkDataPacket parameter part
+ * holds the 21 bits in a private uint32_t
+ * structure: return type - field name - nr of bits
+ * uint8_t mode: 1;
+ * uint8_t team: 3;
+ * uint8_t action: 2;
+ * uint16_t id: 11;
+ * uint8_t hp: 3;
+ * uint8_t ready: 1;
+ */
+class ModeParameter
 {
+private:
   uint32_t raw;
-  struct
-  {
-    uint8_t team: 3;
-    uint8_t action: 2;
-    uint16_t id: 12;
-    uint8_t hp: 3;  //new HP amount
-  };
+public:
+  ModeParameter();
+  ModeParameter(uint32_t raw);
+  uint32_t get_raw();
+  void set_raw(uint32_t raw);
+  uint8_t get_mode();
+  void set_mode(uint8_t mode);
+  uint8_t get_team();
+  void set_team(uint8_t team);
+  uint8_t get_action();
+  void set_action(uint8_t action);
+  uint16_t get_id();
+  void set_id(uint16_t id);
+  uint8_t get_hp();
+  void set_hp(uint8_t hp);
+  uint8_t get_ready();
+  void set_ready(uint8_t ready);
 };
-
-union TriggerParameter
-{
-  uint32_t raw;
-  struct
-  {
-    uint8_t new_team: 3;
-  };
-};
-
-union ModeParameter
-{
-  uint32_t raw;
-  struct
-  {
-    uint8_t mode: 1;
-    uint8_t team: 3;
-    uint8_t action: 2;
-    uint16_t id: 11;
-    uint8_t hp: 3;
-    uint8_t ready: 1;
-  };
-};
-
 
 
 enum DeviceType: uint8_t


### PR DESCRIPTION
C++ does not support union type punning (a C++ union remembers the active member, accessing any other member is undefined behavior)
replace the union with a class with getters and setters with bit-shifts