### PR TITLE
fix for empty packet (ex: in case of wrong crc)

### DIFF
--- a/Sources/2024_blaster/User/main.c
+++ b/Sources/2024_blaster/User/main.c
@@ -254,7 +254,7 @@ void game_loop() {
         if (ir_data_ready())
         {
             IrDataPacket p = get_ir_packet();
-            if (p.team != last_hw_team){
+            if (p.raw != 0 && p.team != last_hw_team){
 
                 if (hitpoints) {
                     hitpoints--;


### PR DESCRIPTION
if get_ir_packet() returns a raw=0 packet (because of a wrong CRC) the packet is still processed, but should not be