### PR TITLE
listen for start pulse + adapt state machine

### DIFF
--- a/Sources/2024_blaster/User/data.h
+++ b/Sources/2024_blaster/User/data.h
@@ -7,6 +7,7 @@
 typedef struct {
     uint32_t raw;
     uint8_t bits_read;
+    uint8_t data_ready;
     uint32_t last_interrupt;
 } DataReader;
 


### PR DESCRIPTION
Currently only 0 and 1 pulses are detected, without first detecting a start pulse.
Added checking for the start pulse and adapted the state-machine for that.
Made it more similar to the blaster2022 code.